### PR TITLE
Timer not starting - short term fix

### DIFF
--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -234,7 +234,7 @@ start
     var isFreshFirstRoom = vars.currentLevelId == 0 && vars.currentPlaceId == 0 /*&& vars.currentPortalId == 0*/;  // Portal id is 0 from a new save, and 1 otherwise (e.g. go into next room and back, then save).
     var isNoLongerOnTitleScreen = DateTime.Now.Subtract(vars.lastDateTimeOnTitleScreen).TotalSeconds > 1;  // Leniency needed when resetting to title screen.
     var inCutscene = current.cursorOff;  // Cursor is off during a cutscene, even when using controller.
-    if (isFreshFirstRoom && isNoLongerOnTitleScreen && inCutscene)
+    if (isFreshFirstRoom && isNoLongerOnTitleScreen /*&& inCutscene*/)
     {
         vars.isTitleScreenToNewSave = true;
     }


### PR DESCRIPTION
Why does this not work?
When the cutscene ends but before we move, nothing prevents us from checking var "inCutscene" again. So, cursor goes back on, so var inCutscene goes to false, and therefore isTitleScreenToNewSave also goes false. Simple as that