### PR TITLE
Add settings.xml + clean-up some code and splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-# Chants of Sennaar Autosplitter v0.1.0
+# Chants of Sennaar Autosplitter v0.1.2
 ## How to install
-1. [Download](https://github.com/just-ero/asl-help/blob/main/lib/asl-help) `asl-help` and place it in your LiveSplit installation folder > Components
+1. [Download](https://github.com/just-ero/asl-help/raw/main/lib/asl-help) `asl-help` and place it in your LiveSplit installation folder > Components
     - E.g. Documents\LiveSplit_1.8.26\Components
-2. Place the .asl file anywhere you want, and then import it into Livesplit
+2. Place `chantsofsennaar.asl` and `chantsofsennaar.Settings.xml` in the same folder as `asl-help` above.
+3. Import the autosplitter into Livesplit
     - Right-click > Edit Layout > plus button to add > Control > Scriptable Auto Splitter > Browse > select the .asl file
-3. If advanced settings appear, you'll know the installation was successful. You can customize the save slot and the splits.
+4. If advanced settings appear, you'll know the installation was successful. You can customize the save slot and the splits.
 ## Current functionalities
 - Automatic splitting on important moments of current Any% route
 - Ability to select the save slot (currently defaults to slot 3)
 ## Known bugs
-- Sometimes the autpsplitter will start too early - during the first cutscene. This is related to performing gamepad inputs during that cutscene.
-  - You can avoid this by waiting with the inputs until the screen fades to black.
-  - If you encounter the bug, you can open and close the Steam overlay to be able to quit to the main menu quicker.
+None as of 27th May 2024
 ## Roadmap
 - [ ] Automatic detection of the save slot
 - [ ] True Ending support 

--- a/chantsofsennaar.Settings.xml
+++ b/chantsofsennaar.Settings.xml
@@ -1,0 +1,51 @@
+<Settings>
+    <Setting Id="game_save_slot" State="true" Label="[Required, select 1] Game save slot" ToolTip="The save slot that will be used for speedruns. Your level/place ids are determined from the save data.">
+        <Setting Id="save_slot_1" State="false" Label="Save slot 1" />
+        <Setting Id="save_slot_2" State="false" Label="Save slot 2" />
+        <Setting Id="save_slot_3" State="true" Label="Save slot 3" />
+    </Setting>
+
+    <Setting Id="any_category" State="true" Label="Any% splits">
+        <Setting Id="crypt_any_splits" State="true" Label="Crypt Any% splits">
+            <Setting Id="first_journal_any_split" State="true" Label="1st journal entry" ToolTip="Complete the 1st journal entry and exit room" />
+            <Setting Id="crypt_exit_any_split" State="true" Label="Exit the Crypt level" ToolTip="Finish the water locks puzzle and exit room" />
+        </Setting>
+
+        <Setting Id="abbey_any_splits" State="true" Label="Abbey (Devotees) Any% splits">
+            <Setting Id="hide_and_seek_any_split" State="true" Label="Finish hide and seek" ToolTip="Finish hide and seek and enter the stealth room" />
+            <Setting Id="pick_up_coin_any_split" State="true" Label="Pick up the coin" />
+            <Setting Id="enter_church_any_split" State="true" Label="Enter the church" />
+            <Setting Id="pick_up_lens_any_split" State="true" Label="Pick up the lens" />
+            <Setting Id="abbey_exit_any_split" State="true" Label="Exit the Abbey level" ToolTip="Exit through the Warrior door" />
+        </Setting>
+
+        <Setting Id="fortress_any_splits" State="true" Label="Fortress (Warriors) Any% splits">
+            <Setting Id="spear_room_any_split" State="true" Label="Exit the room with the spear" />
+            <Setting Id="stealth_start_any_split" State="true" Label="Start the stealth section" />
+            <Setting Id="stealth_corridor_any_split" State="true" Label="Exit the stealth corridor" />
+            <Setting Id="stealth_storage_room_any_split" State="true" Label="Exit the stealth storage room" ToolTip="Exit the storage room (has a elevator with 2 boxes on it and a guard near the exit)" />
+            <Setting Id="armory_exit_any_split" State="true" Label="Exit the armory" ToolTip="Exit the armory after disguising as a guard" />
+            <Setting Id="fortress_exit_any_split" State="true" Label="Exit the Fortress level" ToolTip="Take the elevator to the Gardens" />
+        </Setting>
+
+        <Setting Id="gardens_any_splits" State="true" Label="Gardens (Bards) Any% splits">
+            <Setting Id="servant_door_any_split" State="true" Label="Exit through the servant's door" />
+            <Setting Id="enter_sewers_any_split" State="true" Label="Enter the sewers" />
+            <Setting Id="exit_sewers_any_split" State="true" Label="Exit the sewers" />
+            <Setting Id="pick_up_windmill_torch_any_split" State="true" Label="Pick up the torch at the windmill" />
+            <Setting Id="maze_exit_any_split" State="true" Label="Exit the maze" ToolTip="Note: the maze is technically part of the Factory level, but we consider it as part of the Gardens level" />
+        </Setting>
+
+        <Setting Id="factory_any_splits" State="true" Label="Factory (Alchemists) Any% splits">
+            <Setting Id="tunnels_exit_any_split" State="true" Label="Exit the Tunnels level" ToolTip="Activate and take the elevator from Tunnels to Factory" />
+            <Setting Id="pick_up_silverware_any_split" State="true" Label="Pick up the silverware" ToolTip="Pick up the silverware in the cafeteria" />
+            <Setting Id="pick_up_silver_bar_any_split" State="true" Label="Pick up the silver bar" ToolTip="Pick up the silver bar after melting the silverware" />
+            <Setting Id="factory_exit_any_split" State="true" Label="Exit the Factory level" ToolTip="Place the crafted key into the door and exit through the door" />
+        </Setting>
+
+        <Setting Id="exile_any_splits" State="true" Label="Exile (Anchorites) Any% splits">
+            <Setting Id="exile_npc_room_any_split" State="true" Label="Enter the Creator's room" ToolTip="Enter the Creator's room after entering the code in the keypad" />
+            <Setting Id="pick_up_exile_key_any_split" State="true" Label="Pick up the Exile key" />
+        </Setting>
+    </Setting>
+</Settings>

--- a/chantsofsennaar.Settings.xml
+++ b/chantsofsennaar.Settings.xml
@@ -22,7 +22,7 @@
         <Setting Id="a3ss_fortress" State="true" Label="Fortress (Warriors) Any% splits">
             <Setting Id="a3s_spear_room" State="true" Label="Exit the room with the spear" />
             <Setting Id="a3s_stealth_start" State="true" Label="Start the stealth section" />
-            <Setting Id="a3s_stealth_corridor" State="true" Label="Exit the stealth corridor" />
+            <Setting Id="a3s_stealth_corridor" State="true" Label="Exit the stealth corridor" ToolTip="Exit the long stealth corridor (has a gong)" />
             <Setting Id="a3s_stealth_storage_room" State="true" Label="Exit the stealth storage room" ToolTip="Exit the storage room (has a elevator with 2 boxes on it and a guard near the exit)" />
             <Setting Id="a3s_armory_exit" State="true" Label="Exit the armory" ToolTip="Exit the armory after disguising as a guard" />
             <Setting Id="a3s_fortress_exit" State="true" Label="Exit the Fortress level" ToolTip="Take the elevator to the Gardens" />
@@ -30,8 +30,8 @@
 
         <Setting Id="a4ss_gardens" State="true" Label="Gardens (Bards) Any% splits">
             <Setting Id="a4s_servant_door" State="true" Label="Exit through the servant's door" />
-            <Setting Id="a4s_enter_sewers" State="true" Label="Enter the sewers" />
-            <Setting Id="a4s_exit_sewers" State="true" Label="Exit the sewers" />
+            <Setting Id="a4s_enter_sewers" State="true" Label="Enter the sewers" ToolTip="Enter the sewers to get the compass" />
+            <Setting Id="a4s_exit_sewers" State="true" Label="Exit the sewers" ToolTip="Exit the sewers after getting the compass" />
             <Setting Id="a4s_pick_up_windmill_torch" State="true" Label="Pick up the torch at the windmill" />
             <Setting Id="a4s_maze_exit" State="true" Label="Exit the maze" ToolTip="Note: the maze is technically part of the Factory level, but we consider it as part of the Gardens level" />
         </Setting>
@@ -45,7 +45,7 @@
 
         <Setting Id="a6ss_exile" State="true" Label="Exile (Anchorites) Any% splits">
             <Setting Id="a6s_exile_npc_room" State="true" Label="Enter the Creator's room" ToolTip="Enter the Creator's room after entering the code in the keypad" />
-            <Setting Id="a6s_pick_up_exile_key" State="true" Label="Pick up the Exile key" />
+            <Setting Id="a6s_pick_up_exile_key" State="true" Label="Pick up the Exile key" ToolTip="Pick up the Exile key during the cutscene with the Creator" />
         </Setting>
     </Setting>
 </Settings>

--- a/chantsofsennaar.Settings.xml
+++ b/chantsofsennaar.Settings.xml
@@ -6,46 +6,46 @@
     </Setting>
 
     <Setting Id="any_category" State="true" Label="Any% splits">
-        <Setting Id="crypt_any_splits" State="true" Label="Crypt Any% splits">
-            <Setting Id="first_journal_any_split" State="true" Label="1st journal entry" ToolTip="Complete the 1st journal entry and exit room" />
-            <Setting Id="crypt_exit_any_split" State="true" Label="Exit the Crypt level" ToolTip="Finish the water locks puzzle and exit room" />
+        <Setting Id="a1ss_crypts" State="true" Label="Crypt Any% splits">
+            <Setting Id="a1s_first_journal" State="true" Label="1st journal entry" ToolTip="Finish the 1st journal entry and exit room" />
+            <Setting Id="a1s_crypt_exit" State="true" Label="Exit the Crypt level" ToolTip="Finish the water locks puzzle and exit room" />
         </Setting>
 
-        <Setting Id="abbey_any_splits" State="true" Label="Abbey (Devotees) Any% splits">
-            <Setting Id="hide_and_seek_any_split" State="true" Label="Finish hide and seek" ToolTip="Finish hide and seek and enter the stealth room" />
-            <Setting Id="pick_up_coin_any_split" State="true" Label="Pick up the coin" />
-            <Setting Id="enter_church_any_split" State="true" Label="Enter the church" />
-            <Setting Id="pick_up_lens_any_split" State="true" Label="Pick up the lens" />
-            <Setting Id="abbey_exit_any_split" State="true" Label="Exit the Abbey level" ToolTip="Exit through the Warrior door" />
+        <Setting Id="a2ss_abbey" State="true" Label="Abbey (Devotees) Any% splits">
+            <Setting Id="a2s_hide_and_seek" State="true" Label="Finish hide and seek" ToolTip="Finish hide and seek and enter the stealth room" />
+            <Setting Id="a2s_pick_up_coin" State="true" Label="Pick up the coin" />
+            <Setting Id="a2s_enter_church" State="true" Label="Enter the church" />
+            <Setting Id="a2s_pick_up_lens" State="true" Label="Pick up the lens" />
+            <Setting Id="a2s_abbey_exit" State="true" Label="Exit the Abbey level" ToolTip="Exit through the Warrior door" />
         </Setting>
 
-        <Setting Id="fortress_any_splits" State="true" Label="Fortress (Warriors) Any% splits">
-            <Setting Id="spear_room_any_split" State="true" Label="Exit the room with the spear" />
-            <Setting Id="stealth_start_any_split" State="true" Label="Start the stealth section" />
-            <Setting Id="stealth_corridor_any_split" State="true" Label="Exit the stealth corridor" />
-            <Setting Id="stealth_storage_room_any_split" State="true" Label="Exit the stealth storage room" ToolTip="Exit the storage room (has a elevator with 2 boxes on it and a guard near the exit)" />
-            <Setting Id="armory_exit_any_split" State="true" Label="Exit the armory" ToolTip="Exit the armory after disguising as a guard" />
-            <Setting Id="fortress_exit_any_split" State="true" Label="Exit the Fortress level" ToolTip="Take the elevator to the Gardens" />
+        <Setting Id="a3ss_fortress" State="true" Label="Fortress (Warriors) Any% splits">
+            <Setting Id="a3s_spear_room" State="true" Label="Exit the room with the spear" />
+            <Setting Id="a3s_stealth_start" State="true" Label="Start the stealth section" />
+            <Setting Id="a3s_stealth_corridor" State="true" Label="Exit the stealth corridor" />
+            <Setting Id="a3s_stealth_storage_room" State="true" Label="Exit the stealth storage room" ToolTip="Exit the storage room (has a elevator with 2 boxes on it and a guard near the exit)" />
+            <Setting Id="a3s_armory_exit" State="true" Label="Exit the armory" ToolTip="Exit the armory after disguising as a guard" />
+            <Setting Id="a3s_fortress_exit" State="true" Label="Exit the Fortress level" ToolTip="Take the elevator to the Gardens" />
         </Setting>
 
-        <Setting Id="gardens_any_splits" State="true" Label="Gardens (Bards) Any% splits">
-            <Setting Id="servant_door_any_split" State="true" Label="Exit through the servant's door" />
-            <Setting Id="enter_sewers_any_split" State="true" Label="Enter the sewers" />
-            <Setting Id="exit_sewers_any_split" State="true" Label="Exit the sewers" />
-            <Setting Id="pick_up_windmill_torch_any_split" State="true" Label="Pick up the torch at the windmill" />
-            <Setting Id="maze_exit_any_split" State="true" Label="Exit the maze" ToolTip="Note: the maze is technically part of the Factory level, but we consider it as part of the Gardens level" />
+        <Setting Id="a4ss_gardens" State="true" Label="Gardens (Bards) Any% splits">
+            <Setting Id="a4s_servant_door" State="true" Label="Exit through the servant's door" />
+            <Setting Id="a4s_enter_sewers" State="true" Label="Enter the sewers" />
+            <Setting Id="a4s_exit_sewers" State="true" Label="Exit the sewers" />
+            <Setting Id="a4s_pick_up_windmill_torch" State="true" Label="Pick up the torch at the windmill" />
+            <Setting Id="a4s_maze_exit" State="true" Label="Exit the maze" ToolTip="Note: the maze is technically part of the Factory level, but we consider it as part of the Gardens level" />
         </Setting>
 
-        <Setting Id="factory_any_splits" State="true" Label="Factory (Alchemists) Any% splits">
-            <Setting Id="tunnels_exit_any_split" State="true" Label="Exit the Tunnels level" ToolTip="Activate and take the elevator from Tunnels to Factory" />
-            <Setting Id="pick_up_silverware_any_split" State="true" Label="Pick up the silverware" ToolTip="Pick up the silverware in the cafeteria" />
-            <Setting Id="pick_up_silver_bar_any_split" State="true" Label="Pick up the silver bar" ToolTip="Pick up the silver bar after melting the silverware" />
-            <Setting Id="factory_exit_any_split" State="true" Label="Exit the Factory level" ToolTip="Place the crafted key into the door and exit through the door" />
+        <Setting Id="a5ss_factory" State="true" Label="Factory (Alchemists) Any% splits">
+            <Setting Id="a5s_tunnels_exit" State="true" Label="Exit the Tunnels level" ToolTip="Activate and take the elevator from Tunnels to Factory" />
+            <Setting Id="a5s_pick_up_silverware" State="true" Label="Pick up the silverware" ToolTip="Pick up the silverware in the cafeteria" />
+            <Setting Id="a5s_pick_up_silver_bar" State="true" Label="Pick up the silver bar" ToolTip="Pick up the silver bar after melting the silverware" />
+            <Setting Id="a5s_factory_exit" State="true" Label="Exit the Factory level" ToolTip="Place the crafted key into the door and exit through the door" />
         </Setting>
 
-        <Setting Id="exile_any_splits" State="true" Label="Exile (Anchorites) Any% splits">
-            <Setting Id="exile_npc_room_any_split" State="true" Label="Enter the Creator's room" ToolTip="Enter the Creator's room after entering the code in the keypad" />
-            <Setting Id="pick_up_exile_key_any_split" State="true" Label="Pick up the Exile key" />
+        <Setting Id="a6ss_exile" State="true" Label="Exile (Anchorites) Any% splits">
+            <Setting Id="a6s_exile_npc_room" State="true" Label="Enter the Creator's room" ToolTip="Enter the Creator's room after entering the code in the keypad" />
+            <Setting Id="a6s_pick_up_exile_key" State="true" Label="Pick up the Exile key" />
         </Setting>
     </Setting>
 </Settings>

--- a/chantsofsennaar.Settings.xml
+++ b/chantsofsennaar.Settings.xml
@@ -6,16 +6,16 @@
     </Setting>
 
     <Setting Id="any_category" State="true" Label="Any% splits">
-        <Setting Id="a1ss_crypts" State="true" Label="Crypt Any% splits">
-            <Setting Id="a1s_first_journal" State="true" Label="1st journal entry" ToolTip="Finish the 1st journal entry and exit room" />
-            <Setting Id="a1s_crypt_exit" State="true" Label="Exit the Crypt level" ToolTip="Finish the water locks puzzle and exit room" />
+        <Setting Id="a1ss_crypt" State="true" Label="Crypt Any% splits">
+            <Setting Id="a1s_first_journal" State="true" Label="1st journal entry" ToolTip="Finish the 1st journal entry and exit the room" />
+            <Setting Id="a1s_crypt_exit" State="true" Label="Exit the Crypt level" ToolTip="Finish the water locks puzzle and exit the room" />
         </Setting>
 
         <Setting Id="a2ss_abbey" State="true" Label="Abbey (Devotees) Any% splits">
             <Setting Id="a2s_hide_and_seek" State="true" Label="Finish hide and seek" ToolTip="Finish hide and seek and enter the stealth room" />
-            <Setting Id="a2s_pick_up_coin" State="true" Label="Pick up the coin" />
+            <Setting Id="a2s_pick_up_coin" State="true" Label="Pick up the coin" ToolTip="Pick up the coin after finishing the bed puzzle" />
             <Setting Id="a2s_enter_church" State="true" Label="Enter the church" />
-            <Setting Id="a2s_pick_up_lens" State="true" Label="Pick up the lens" />
+            <Setting Id="a2s_pick_up_lens" State="true" Label="Pick up the lens" ToolTip="Pick up the lens after getting the key from the jar and opening the door" />
             <Setting Id="a2s_abbey_exit" State="true" Label="Exit the Abbey level" ToolTip="Exit through the Warrior door" />
         </Setting>
 

--- a/chantsofsennaar.Settings.xml
+++ b/chantsofsennaar.Settings.xml
@@ -38,7 +38,7 @@
 
         <Setting Id="a5ss_factory" State="true" Label="Factory (Alchemists) Any% splits">
             <Setting Id="a5s_tunnels_exit" State="true" Label="Exit the Tunnels level" ToolTip="Activate and take the elevator from Tunnels to Factory" />
-            <Setting Id="a5s_pick_up_silverware" State="true" Label="Pick up the silverware" ToolTip="Pick up the silverware in the cafeteria" />
+            <Setting Id="a5s_pick_up_silverware" State="true" Label="Pick up the silverware" ToolTip="Pick up the silverware in the canteen" />
             <Setting Id="a5s_pick_up_silver_bar" State="true" Label="Pick up the silver bar" ToolTip="Pick up the silver bar after melting the silverware" />
             <Setting Id="a5s_factory_exit" State="true" Label="Exit the Factory level" ToolTip="Place the crafted key into the door and exit through the door" />
         </Setting>

--- a/chantsofsennaar.Settings.xml
+++ b/chantsofsennaar.Settings.xml
@@ -37,7 +37,8 @@
         </Setting>
 
         <Setting Id="a5ss_factory" State="true" Label="Factory (Alchemists) Any% splits">
-            <Setting Id="a5s_tunnels_exit" State="true" Label="Exit the Tunnels level" ToolTip="Activate and take the elevator from Tunnels to Factory" />
+            <Setting Id="a5s_escape_monster" State="true" Label="Escape the monster" ToolTip="Escape the monster and enter the room to activate the elevator" />
+            <Setting Id="a5s_trigger_canteen_timer" State="true" Label="Trigger the canteen timer" ToolTip="Trigger the canteen timer by entering the foyer. The canteen should open in ~3min30s." />
             <Setting Id="a5s_pick_up_silverware" State="true" Label="Pick up the silverware" ToolTip="Pick up the silverware in the canteen" />
             <Setting Id="a5s_pick_up_silver_bar" State="true" Label="Pick up the silver bar" ToolTip="Pick up the silver bar after melting the silverware" />
             <Setting Id="a5s_factory_exit" State="true" Label="Exit the Factory level" ToolTip="Place the crafted key into the door and exit through the door" />

--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -189,7 +189,7 @@ split
     /* This only works for Any% category. */
 
     // Crypt splits
-    if (vars.oldLevelId == 0 && vars.currentLevelId == 0 && vars.currentPlaceId <= 6 && settings["a1ss_crypt"])
+    if (vars.oldLevelId == 0 && vars.currentLevelId == 0 && vars.currentPlaceId <= 6)
     {
         // Finish the 1st journal entry and exit the room.
         var isFirstJournalSplit = vars.oldPlaceId == 3 && vars.currentPlaceId == 4 && settings["a1s_first_journal"];
@@ -200,7 +200,7 @@ split
     }
 
     // Abbey (Devotees) splits
-    if (vars.oldLevelId == 0 && settings["a2ss_abbey"])
+    if (vars.oldLevelId == 0)
     {
         // Abbey -> Fortress.
         if (vars.currentLevelId == 1 && settings["a2s_abbey_exit"])
@@ -227,7 +227,7 @@ split
     }
 
     // Fortress (Warriors) splits
-    if (vars.oldLevelId == 1 && settings["a3ss_fortress"])
+    if (vars.oldLevelId == 1)
     {
         // Fortress -> Gardens.
         if (vars.currentLevelId == 2 && settings["a3s_fortress_exit"])
@@ -256,7 +256,7 @@ split
     }
 
     // Gardens (Bards) splits    
-    if (vars.oldLevelId == 2 && vars.currentLevelId == 2 && settings["a4ss_gardens"])
+    if (vars.oldLevelId == 2 && vars.currentLevelId == 2)
     {
         // Exit through the servant's door.
         var isServantDoorSplit = vars.oldPlaceId == 2 && vars.currentPlaceId == 5 && settings["a4s_servant_door"];
@@ -274,15 +274,9 @@ split
     if (vars.oldLevelId == 3)
     {
         // Exit the maze (considered part of the Gardens level).
-        if (vars.oldPlaceId == 7 && vars.currentPlaceId == 8 && settings["a4ss_gardens"] && settings["a4s_maze_exit"])
+        if (vars.oldPlaceId == 7 && vars.currentPlaceId == 8 && settings["a4s_maze_exit"])
         {
             return true;
-        }
-
-        // Exit early if factory splits are not enabled.
-        if (!settings["a5ss_factory"])
-        {
-            return false;
         }
 
         // Factory -> Exile.
@@ -314,12 +308,6 @@ split
         if (vars.currentPlaceId == 2 && !current.canPlayerRun && !old.cursorOff && current.cursorOff)
         {
             return true;
-        }
-
-        // Exit early if exile splits are not enabled.
-        if (!settings["a6ss_exile"])
-        {
-            return false;
         }
 
         // Enter the Creator's room after entering the 3-glyph code in the keypad.

--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -189,48 +189,48 @@ split
     /* This only works for Any% category. */
 
     // Crypt splits
-    if (vars.oldLevelId == 0 && vars.currentLevelId == 0 && vars.currentPlaceId <= 6 && settings["crypt_splits"])
+    if (vars.oldLevelId == 0 && vars.currentLevelId == 0 && vars.currentPlaceId <= 6 && settings["a1ss_crypt"])
     {
-        // Complete the 1st journal entry and leave the room.
-        var isFirstJournalSplit = vars.oldPlaceId == 3 && vars.currentPlaceId == 4 && settings["first_journal_split"];
-        // Crypt -> Abbey
-        var isCryptExitSplit = vars.oldPlaceId == 5 && vars.currentPlaceId == 6 && settings["crypt_exit_split"];
+        // Finish the 1st journal entry and exit the room.
+        var isFirstJournalSplit = vars.oldPlaceId == 3 && vars.currentPlaceId == 4 && settings["a1s_first_journal"];
+        // Crypt -> Abbey (finish the water locks puzzle and exit the room)
+        var isCryptExitSplit = vars.oldPlaceId == 5 && vars.currentPlaceId == 6 && settings["a1s_crypt_exit"];
 
         return isFirstJournalSplit || isCryptExitSplit;
     }
 
     // Abbey (Devotees) splits
-    if (vars.oldLevelId == 0 && settings["abbey_splits"])
+    if (vars.oldLevelId == 0 && settings["a2ss_abbey"])
     {
         // Abbey -> Fortress.
-        if (vars.currentLevelId == 1 && settings["abbey_exit_split"])
+        if (vars.currentLevelId == 1 && settings["a2s_abbey_exit"])
         {
             return true;
         }
 
-        // Exit early if current level is not Abbey to avoid duplicate check.
+        // Exit early if current level is not Abbey to avoid duplicate checks below.
         if (vars.currentLevelId != 0)
         {
             return false;
         }
 
-        // Finish hide and seek.
-        var isHideAndSeekSplit = vars.oldPlaceId == 9 && vars.currentPlaceId == 11 && settings["hide_and_seek_split"];
-        // Pick up coin item.
-        var isPickUpCoinSplit = vars.currentPlaceId == 17 && vars.isInventoryForcedOpen && settings["pick_up_coin_split"];
+        // Finish hide and seek and enter the stealth room.
+        var isHideAndSeekSplit = vars.oldPlaceId == 9 && vars.currentPlaceId == 11 && settings["a2s_hide_and_seek"];
+        // Pick up the coin item by finishing the bed puzzle.
+        var isPickUpCoinSplit = vars.currentPlaceId == 17 && vars.isInventoryForcedOpen && settings["a2s_pick_up_coin"];
         // Enter the church.
-        var isEnterChurchSplit = vars.oldPlaceId == 12 && vars.currentPlaceId == 21 && settings["enter_church_split"];
-        // Pick up lens item.
-        var isPickUpLensSplit = vars.currentPlaceId == 23 && vars.isInventoryForcedOpen && settings["pick_up_lens_split"];
+        var isEnterChurchSplit = vars.oldPlaceId == 12 && vars.currentPlaceId == 21 && settings["a2s_enter_church"];
+        // Pick up the lens item after getting the key from the jar and opening the door.
+        var isPickUpLensSplit = vars.currentPlaceId == 23 && vars.isInventoryForcedOpen && settings["a2s_pick_up_lens"];
 
         return isHideAndSeekSplit || isPickUpCoinSplit || isEnterChurchSplit || isPickUpLensSplit;
     }
 
     // Fortress (Warriors) splits
-    if (vars.oldLevelId == 1 && settings["fortress_splits"])
+    if (vars.oldLevelId == 1 && settings["a3ss_fortress"])
     {
         // Fortress -> Gardens.
-        if (vars.currentLevelId == 2 && settings["fortress_exit_split"])
+        if (vars.currentLevelId == 2 && settings["a3s_fortress_exit"])
         {
             return true;
         }
@@ -241,62 +241,68 @@ split
             return false;
         }
 
-        // Pick up spear item.
-        var isSpearTerminalRoomSplit = vars.oldPlaceId == 7 && vars.currentPlaceId == 8 && settings["spear_terminal_room_split"];
-        // Enter first stealth room.
-        var isStealthStartSplit = vars.oldPlaceId == 9 && vars.currentPlaceId == 11 && settings["stealth_start_split"];
-        // Exit stealth corridor room.
-        var isStealthCorridorSplit = vars.oldPlaceId == 0 && vars.currentPlaceId == 12 && settings["stealth_corridor_split"];
-        // Exit stealth storage room (with an elevator w/ 2 boxes).
-        var isStealthStorageRoomSplit = vars.oldPlaceId == 13 && vars.currentPlaceId == 14 && settings["stealth_storage_room_split"];
-        // Exit armory room, after disguising as a guard.
-        var isArmoryExitSplit = vars.oldPlaceId == 16 && vars.currentPlaceId == 14 && settings["armory_exit_split"];
+        // Exit the room with the spear.
+        var isSpearRoomSplit = vars.oldPlaceId == 7 && vars.currentPlaceId == 8 && settings["a3s_spear_room"];
+        // Enter the first stealth room.
+        var isStealthStartSplit = vars.oldPlaceId == 9 && vars.currentPlaceId == 11 && settings["a3s_stealth_start"];
+        // Exit the stealth corridor.
+        var isStealthCorridorSplit = vars.oldPlaceId == 0 && vars.currentPlaceId == 12 && settings["a3s_stealth_corridor"];
+        // Exit the stealth storage room (has an elevator wtih 2 boxes).
+        var isStealthStorageRoomSplit = vars.oldPlaceId == 13 && vars.currentPlaceId == 14 && settings["a3s_stealth_storage_room"];
+        // Exit the armory room after disguising as a guard.
+        var isArmoryExitSplit = vars.oldPlaceId == 16 && vars.currentPlaceId == 14 && settings["a3s_armory_exit"];
 
-        return isSpearTerminalRoomSplit || isStealthStartSplit || isStealthCorridorSplit || isStealthStorageRoomSplit || isArmoryExitSplit;
+        return isSpearRoomSplit || isStealthStartSplit || isStealthCorridorSplit || isStealthStorageRoomSplit || isArmoryExitSplit;
     }
 
     // Gardens (Bards) splits    
-    if (vars.oldLevelId == 2 && vars.currentLevelId == 2 && settings["gardens_splits"])
+    if (vars.oldLevelId == 2 && vars.currentLevelId == 2 && settings["a4ss_gardens"])
     {
-        // Exit through door that servant opens.
-        var isServantDoorSplit = vars.oldPlaceId == 2 && vars.currentPlaceId == 5 && settings["servant_door_split"];
+        // Exit through the servant's door.
+        var isServantDoorSplit = vars.oldPlaceId == 2 && vars.currentPlaceId == 5 && settings["a4s_servant_door"];
         // Enter sewers.
-        var isEnterSewersSplit = vars.oldPlaceId == 15 && vars.currentPlaceId == 11 && settings["enter_sewers_split"];
+        var isEnterSewersSplit = vars.oldPlaceId == 15 && vars.currentPlaceId == 11 && settings["a4s_enter_sewers"];
         // Exit sewers.
-        var isExitSewersSplit = vars.oldPlaceId == 11 && vars.currentPlaceId == 15 && settings["exit_sewers_split"];
+        var isExitSewersSplit = vars.oldPlaceId == 11 && vars.currentPlaceId == 15 && settings["a4s_exit_sewers"];
         // Pick up torch item at windmill.
-        var isPickUpWindmillTorchSplit = vars.currentPlaceId == 18 && vars.isInventoryForcedOpen && settings["pick_up_windmill_torch_split"];
+        var isPickUpWindmillTorchSplit = vars.currentPlaceId == 18 && vars.isInventoryForcedOpen && settings["a4s_pick_up_windmill_torch"];
 
         return isServantDoorSplit || isEnterSewersSplit || isExitSewersSplit || isPickUpWindmillTorchSplit;
     }
 
-    // Factory (Alchemists) splits (and Maze)
+    // Factory (Alchemists) splits (+ Maze)
     if (vars.oldLevelId == 3)
     {
         // Exit the maze (considered part of the Gardens level).
-        if (vars.oldPlaceId == 7 && vars.currentPlaceId == 8 && settings["gardens_splits"] && settings["maze_exit_split"])
+        if (vars.oldPlaceId == 7 && vars.currentPlaceId == 8 && settings["a4ss_gardens"] && settings["a4s_maze_exit"])
         {
             return true;
         }
 
-        // Factory -> Exile
-        if (vars.currentLevelId == 4 && settings["factory_splits"] && settings["factory_exit_split"])
+        // Exit early if factory splits are not enabled.
+        if (!settings["a5ss_factory"])
+        {
+            return false;
+        }
+
+        // Factory -> Exile.
+        if (vars.currentLevelId == 4 && settings["a5s_factory_exit"])
         {
             return true;
         }
 
         // Exit early if current level is not Factory to avoid duplicate check.
-        if (vars.currentLevelId != 3 || !settings["factory_splits"]) // Moved factory splits check here to allow for maze split.
+        if (vars.currentLevelId != 3)
         {
             return false;
         }
 
         // Tunnels -> Factory
-        var isTunnelExitSplit = vars.oldPlaceId == 14 && vars.currentPlaceId == 16 && settings["tunnels_exit_split"];
+        var isTunnelExitSplit = vars.oldPlaceId == 14 && vars.currentPlaceId == 16 && settings["a5s_tunnels_exit"];
         // Pick up silverware item at canteen.
-        var isPickUpSilverwareSplit = vars.currentPlaceId == 33 && vars.isInventoryForcedOpen && settings["pick_up_silverware_split"];
+        var isPickUpSilverwareSplit = vars.currentPlaceId == 33 && vars.isInventoryForcedOpen && settings["a5s_pick_up_silverware"];
         // Pick up silver bar item after melting the silverware.
-        var isPickUpSilverBarSplit = vars.currentPlaceId == 22 && vars.isInventoryForcedOpen && settings["pick_up_silver_bar"];
+        var isPickUpSilverBarSplit = vars.currentPlaceId == 22 && vars.isInventoryForcedOpen && settings["a5s_pick_up_silver_bar"];
 
         return isTunnelExitSplit || isPickUpSilverwareSplit || isPickUpSilverBarSplit;
     }
@@ -304,20 +310,22 @@ split
     // Exile (Anchorites) splits
     if (vars.oldLevelId == 4 && vars.currentLevelId == 4)
     {   
-        // Final split for player starting cutscene in final room in Exile. Not optional
-        if (vars.currentPlaceId == 2 && !current.canPlayerRun && !old.cursorOff && current.cursorOff) {
+        // Final split for player starting cutscene in final room in Exile. Not optional.
+        if (vars.currentPlaceId == 2 && !current.canPlayerRun && !old.cursorOff && current.cursorOff)
+        {
             return true;
         }
 
-        // Exit early if splits not selected
-        if (!settings["exile_splits"])
+        // Exit early if exile splits are not enabled.
+        if (!settings["a6ss_exile"])
         {
             return false;
         }
+
         // Enter the Creator's room after entering the 3-glyph code in the keypad.
-        var isExileNpcRoomSplit = vars.oldPlaceId == 15 && vars.currentPlaceId == 6 && settings["exile_npc_room_split"];
+        var isExileNpcRoomSplit = vars.oldPlaceId == 15 && vars.currentPlaceId == 6 && settings["a6s_exile_npc_room"];
         // Pick up Exile key.
-        var isPickUpExileKeySplit = vars.currentPlaceId == 24 && vars.isInventoryForcedOpen && settings["pick_up_exile_key_split"];
+        var isPickUpExileKeySplit = vars.currentPlaceId == 24 && vars.isInventoryForcedOpen && settings["a6s_pick_up_exile_key"];
 
         return isExileNpcRoomSplit || isPickUpExileKeySplit;
     }    

--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -187,33 +187,16 @@ split
        ---- Testing logic above ---- */
 
     /* This only works for Any% category. */
-
-    // Crypt splits
-    if (vars.oldLevelId == 0 && vars.currentLevelId == 0 && vars.currentPlaceId <= 6)
+    // Crypt + Abbey (Devotees) splits
+    if (vars.oldLevelId == 0 && vars.currentLevelId == 0)
     {
+        /* Crypt splits */
         // Finish the 1st journal entry and exit the room.
         var isFirstJournalSplit = vars.oldPlaceId == 3 && vars.currentPlaceId == 4 && settings["a1s_first_journal"];
         // Crypt -> Abbey (finish the water locks puzzle and exit the room)
         var isCryptExitSplit = vars.oldPlaceId == 5 && vars.currentPlaceId == 6 && settings["a1s_crypt_exit"];
 
-        return isFirstJournalSplit || isCryptExitSplit;
-    }
-
-    // Abbey (Devotees) splits
-    if (vars.oldLevelId == 0)
-    {
-        // Abbey -> Fortress.
-        if (vars.currentLevelId == 1 && settings["a2s_abbey_exit"])
-        {
-            return true;
-        }
-
-        // Exit early if current level is not Abbey to avoid duplicate checks below.
-        if (vars.currentLevelId != 0)
-        {
-            return false;
-        }
-
+        /* Abbey splits */
         // Finish hide and seek and enter the stealth room.
         var isHideAndSeekSplit = vars.oldPlaceId == 9 && vars.currentPlaceId == 11 && settings["a2s_hide_and_seek"];
         // Pick up the coin item by finishing the bed puzzle.
@@ -223,24 +206,18 @@ split
         // Pick up the lens item after getting the key from the jar and opening the door.
         var isPickUpLensSplit = vars.currentPlaceId == 23 && vars.isInventoryForcedOpen && settings["a2s_pick_up_lens"];
 
-        return isHideAndSeekSplit || isPickUpCoinSplit || isEnterChurchSplit || isPickUpLensSplit;
+        return isFirstJournalSplit || isCryptExitSplit || isHideAndSeekSplit || isPickUpCoinSplit || isEnterChurchSplit || isPickUpLensSplit;
+    }
+
+    // Abbey -> Fortress
+    if (vars.oldLevelId == 0 && vars.currentLevelId == 1 && settings["a2s_abbey_exit"])
+    {
+        return true;
     }
 
     // Fortress (Warriors) splits
-    if (vars.oldLevelId == 1)
+    if (vars.oldLevelId == 1 && vars.currentLevelId == 1)
     {
-        // Fortress -> Gardens.
-        if (vars.currentLevelId == 2 && settings["a3s_fortress_exit"])
-        {
-            return true;
-        }
-
-        // Exit early if current level is not Fortress to avoid duplicate check.
-        if (vars.currentLevelId != 1)
-        {
-            return false;
-        }
-
         // Exit the room with the spear.
         var isSpearRoomSplit = vars.oldPlaceId == 7 && vars.currentPlaceId == 8 && settings["a3s_spear_room"];
         // Enter the first stealth room.
@@ -253,6 +230,12 @@ split
         var isArmoryExitSplit = vars.oldPlaceId == 16 && vars.currentPlaceId == 14 && settings["a3s_armory_exit"];
 
         return isSpearRoomSplit || isStealthStartSplit || isStealthCorridorSplit || isStealthStorageRoomSplit || isArmoryExitSplit;
+    }
+
+    // Fortress -> Gardens.
+    if (vars.oldLevelId == 1 && vars.currentLevelId == 2 && settings["a3s_fortress_exit"])
+    {
+        return true;
     }
 
     // Gardens (Bards) splits    
@@ -270,51 +253,39 @@ split
         return isServantDoorSplit || isEnterSewersSplit || isExitSewersSplit || isPickUpWindmillTorchSplit;
     }
 
-    // Factory (Alchemists) splits (+ Maze)
-    if (vars.oldLevelId == 3)
+    /* Skipping Gardens -> Tunnels split, since we're considering the maze as part of Gardens */
+
+    // Factory (Alchemists) splits (+ maze)
+    if (vars.oldLevelId == 3 && vars.currentLevelId == 3)
     {
-        // Exit the maze (considered part of the Gardens level).
-        if (vars.oldPlaceId == 7 && vars.currentPlaceId == 8 && settings["a4s_maze_exit"])
-        {
-            return true;
-        }
-
-        // Factory -> Exile.
-        if (vars.currentLevelId == 4 && settings["a5s_factory_exit"])
-        {
-            return true;
-        }
-
-        // Exit early if current level is not Factory to avoid duplicate check.
-        if (vars.currentLevelId != 3)
-        {
-            return false;
-        }
-
-        // Tunnels -> Factory
+        // Exit the maze.
+        var isMazeExitSplit = vars.oldPlaceId == 7 && vars.currentPlaceId == 8 && settings["a4s_maze_exit"];
+        // Exit the Tunnels level.
         var isTunnelExitSplit = vars.oldPlaceId == 14 && vars.currentPlaceId == 16 && settings["a5s_tunnels_exit"];
         // Pick up silverware item at canteen.
         var isPickUpSilverwareSplit = vars.currentPlaceId == 33 && vars.isInventoryForcedOpen && settings["a5s_pick_up_silverware"];
         // Pick up silver bar item after melting the silverware.
         var isPickUpSilverBarSplit = vars.currentPlaceId == 22 && vars.isInventoryForcedOpen && settings["a5s_pick_up_silver_bar"];
 
-        return isTunnelExitSplit || isPickUpSilverwareSplit || isPickUpSilverBarSplit;
+        return isMazeExitSplit || isTunnelExitSplit || isPickUpSilverwareSplit || isPickUpSilverBarSplit;
+    }
+
+    // Factory -> Exile.
+    if (vars.oldLevelId == 3 && vars.currentLevelId == 4 && settings["a5s_factory_exit"])
+    {
+        return true;
     }
 
     // Exile (Anchorites) splits
     if (vars.oldLevelId == 4 && vars.currentLevelId == 4)
-    {   
-        // Final split for player starting cutscene in final room in Exile. Not optional.
-        if (vars.currentPlaceId == 2 && !current.canPlayerRun && !old.cursorOff && current.cursorOff)
-        {
-            return true;
-        }
-
+    {
         // Enter the Creator's room after entering the 3-glyph code in the keypad.
         var isExileNpcRoomSplit = vars.oldPlaceId == 15 && vars.currentPlaceId == 6 && settings["a6s_exile_npc_room"];
         // Pick up Exile key.
         var isPickUpExileKeySplit = vars.currentPlaceId == 24 && vars.isInventoryForcedOpen && settings["a6s_pick_up_exile_key"];
+        // Final split for player starting cutscene in final room in Exile. Not optional.
+        var isFinalCutsceneSplit = vars.currentPlaceId == 2 && !current.canPlayerRun && !old.cursorOff && current.cursorOff;
 
-        return isExileNpcRoomSplit || isPickUpExileKeySplit;
+        return isExileNpcRoomSplit || isPickUpExileKeySplit || isFinalCutsceneSplit;
     }    
 }

--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -126,6 +126,7 @@ onReset
     vars.isTitleScreenToNewSave = false;
     vars.isInventoryForcedOpenNeeded = false;
     vars.isInventoryForcedOpen = false;
+    vars.isCanteenTimerTriggered = false;
 }
 
 start
@@ -163,8 +164,6 @@ start
     {
         vars.isTitleScreenToNewSave = true;
     }
-
-    // IMPORTANT!!! either inCutscene or currentPortalId causes the autosplitter not to start
 }
 
 onStart
@@ -174,6 +173,7 @@ onStart
     vars.isTitleScreenToNewSave = false;
     vars.isInventoryForcedOpenNeeded = false;
     vars.isInventoryForcedOpen = false;
+    vars.isCanteenTimerTriggered = false;
 }
 
 split
@@ -260,14 +260,22 @@ split
     {
         // Exit the maze.
         var isMazeExitSplit = vars.oldPlaceId == 7 && vars.currentPlaceId == 8 && settings["a4s_maze_exit"];
-        // Exit the Tunnels level.
-        var isTunnelExitSplit = vars.oldPlaceId == 14 && vars.currentPlaceId == 16 && settings["a5s_tunnels_exit"];
+        // Escape the monster.
+        var isEscapeMonsterSplit = vars.oldPlaceId == 13 && vars.currentPlaceId == 14 && settings["a5s_escape_monster"];
+        // Trigger the canteen timer (i.e. enter the canteen foyer for the 1st time).
+        var isTriggerCanteenTimerSplit = vars.oldPlaceId == 31 && vars.currentPlaceId == 32 && !vars.isCanteenTimerTriggered && settings["a5s_trigger_canteen_timer"];
         // Pick up silverware item at canteen.
         var isPickUpSilverwareSplit = vars.currentPlaceId == 33 && vars.isInventoryForcedOpen && settings["a5s_pick_up_silverware"];
         // Pick up silver bar item after melting the silverware.
         var isPickUpSilverBarSplit = vars.currentPlaceId == 22 && vars.isInventoryForcedOpen && settings["a5s_pick_up_silver_bar"];
 
-        return isMazeExitSplit || isTunnelExitSplit || isPickUpSilverwareSplit || isPickUpSilverBarSplit;
+        // Set vars.isCanteenTimerTriggered so split isn't triggered again when entering the canteen.
+        if (isTriggerCanteenTimerSplit)
+        {
+            vars.isCanteenTimerTriggered = true;
+        }
+
+        return isMazeExitSplit || isEscapeMonsterSplit || isTriggerCanteenTimerSplit || isPickUpSilverwareSplit || isPickUpSilverBarSplit;
     }
 
     // Factory -> Exile.

--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -4,89 +4,10 @@ state("Chants Of Sennaar", "v.1.0.0.9")
 
 startup
 {
-    // Settings for game save slots.
-    settings.Add("game_save_slot", true, "[Required, select 1] Game save slot");
-    settings.SetToolTip("game_save_slot", "The save slot that will be used for speedruns. Your level/place ids are determined from the save data.");
-
-    settings.CurrentDefaultParent = "game_save_slot";
-    settings.Add("save_slot_1", false, "Save slot 1");
-    settings.Add("save_slot_2", false, "Save slot 2");
-    settings.Add("save_slot_3", true, "Save slot 3");
-
-    // Settings for Crypt level splits.
-    settings.CurrentDefaultParent = null;
-    settings.Add("crypt_splits", true, "Crypt splits");
-
-    settings.CurrentDefaultParent = "crypt_splits";
-    settings.Add("first_journal_split", true, "1st journal entry");
-    settings.SetToolTip("first_journal_split", "Complete the 1st journal entry and exit room");
-    settings.Add("crypt_exit_split", true, "Exit the Crypt level");
-    settings.SetToolTip("crypt_exit_split", "Finish the water locks puzzle and exit room");
-
-    // Settings for Abbey (Devotees) level splits 
-    settings.CurrentDefaultParent = null;
-    settings.Add("abbey_splits", true, "Abbey (Devotees) splits");
-
-    settings.CurrentDefaultParent = "abbey_splits";
-    settings.Add("hide_and_seek_split", true, "Finish hide and seek");
-    settings.SetToolTip("hide_and_seek_split", "Finish hide and seek and enter the stealth room");
-    settings.Add("pick_up_coin_split", true, "Pick up the coin");
-    settings.Add("enter_church_split", true, "Enter the church");
-    settings.Add("pick_up_lens_split", true, "Pick up the lens");
-    settings.Add("abbey_exit_split", true, "Exit the Abbey level");
-
-    // Settings for Fortress (Warriors) level splits
-    settings.CurrentDefaultParent = null;
-    settings.Add("fortress_splits", true, "Fortress (Warriors) splits");
-
-    settings.CurrentDefaultParent = "fortress_splits";
-    settings.Add("spear_terminal_room_split", true, "Exit the room with the spear");
-    settings.Add("stealth_start_split", true, "Start the stealth section");
-    settings.Add("stealth_corridor_split", true, "Exit the stealth corridor");
-    settings.Add("stealth_storage_room_split", true, "Exit the stealth storage room");
-    settings.SetToolTip("stealth_storage_room_split", "Exit the storage room (has a elevator with 2 boxes on it and a guard near the exit)");
-    settings.Add("armory_exit_split", true, "Exit the armory");
-    settings.SetToolTip("armory_exit_split", "Exit the armory after disguising as a guard");
-    settings.Add("fortress_exit_split", true, "Exit the Fortress level");
-    settings.SetToolTip("fortress_exit_split", "Take the elevator to the Gardens");
-
-    // Settings for Gardens (Bards) level splits
-    settings.CurrentDefaultParent = null;
-    settings.Add("gardens_splits", true, "Gardens (Bards) splits");
-
-    settings.CurrentDefaultParent = "gardens_splits";
-    settings.Add("servant_door_split", true, "Exit through the servant's door");
-    settings.Add("enter_sewers_split", true, "Enter the sewers");
-    settings.Add("exit_sewers_split", true, "Exit the sewers");
-    settings.Add("pick_up_windmill_torch_split", true, "Pick up the torch");
-    settings.SetToolTip("pick_up_windmill_torch_split", "Pick up the torch at the windmill");
-    settings.Add("maze_exit_split", true, "Exit the maze");
-
-    // Settings for Factory (Alchemists) level splits
-    settings.CurrentDefaultParent = null;
-    settings.Add("factory_splits", true, "Factory (Alchemists) splits");
-
-    settings.CurrentDefaultParent = "factory_splits";
-    settings.Add("tunnels_exit_split", true, "Exit the Tunnels level");
-    settings.SetToolTip("tunnels_exit_split", "Activate and take the elevator from Tunnels to Factory");
-    settings.Add("pick_up_silverware_split", true, "Pick up the silverware");
-    settings.Add("pick_up_silver_bar", true, "Pick up the silver bar");
-    settings.SetToolTip("pick_up_silver_bar", "Pick up the silver bar after melting the silverware");
-    settings.Add("factory_exit_split", true, "Exit the Factory level");
-    settings.SetToolTip("factory_exit_split", "Place the crafted key into the door and exit room");
-
-    // Settings for Exile (Anchorites) level splits
-    settings.CurrentDefaultParent = null;
-    settings.Add("exile_splits", true, "Exile (Anchorites) splits");
-
-    settings.CurrentDefaultParent = "exile_splits";
-    settings.Add("exile_npc_room_split", true, "Enter the Creator's room");
-    settings.SetToolTip("exile_npc_room_split", "Enter the Creator's room after entering the code in the keypad");
-    settings.Add("pick_up_exile_key_split", true, "Pick up the Exile key");
-
-    // Load the asl-help script
+    // Load the asl-help script and settings
     Assembly.Load(File.ReadAllBytes("Components/asl-help")).CreateInstance("Unity");
     vars.Helper.GameName = "Chants of Sennaar";
+    vars.Helper.Settings.CreateFromXml("Components/chantsofsennaar.Settings.xml");
 }
 
 init
@@ -399,7 +320,5 @@ split
         var isPickUpExileKeySplit = vars.currentPlaceId == 24 && vars.isInventoryForcedOpen && settings["pick_up_exile_key_split"];
 
         return isExileNpcRoomSplit || isPickUpExileKeySplit;
-    }
-
-    
+    }    
 }


### PR DESCRIPTION
PR changes have been tested in a full run to ensure splits are not broken. Note the split changes below.

Changes:
* Splits
  * Move "Tunnels exit" split one room earlier and rename to "Monster escape"
  * Add split for triggering canteen timer to make it easier for true ending runners
* Settings
  * Move settings into `chantsofsennaar.settings.xml`
    * This file is expected in your LiveSplit installation > Components, just like `asl-help`
  * Add Any% parent to existing split settings to prepare for True Ending split settings
  * Rename settings internally
    * Split setting are named like `a3s_armory_exit` for any%, 3rd level, split
      * True ending will have prefix of `t3s` instead
    * Level-tier settings are named like `a1ss_crypt` for any%, 1st level, splits
  * Add additional tooltips to some settings
* Script
  * Remove checks for level splits (e..g settings["abbey_splits"]), since if the checkbox is disabled, then all the split settings below will be set to false anyways
  * Restructure split logic slightly so level transition splits are clearer (and removes some unnecessary `if` statements)