### PR TITLE
Auto slot detect

### DIFF
--- a/chantsofsennaar.Settings.xml
+++ b/chantsofsennaar.Settings.xml
@@ -1,10 +1,4 @@
 <Settings>
-    <Setting Id="game_save_slot" State="true" Label="[Required, select 1] Game save slot" ToolTip="The save slot that will be used for speedruns. Your level/place ids are determined from the save data.">
-        <Setting Id="save_slot_1" State="false" Label="Save slot 1" />
-        <Setting Id="save_slot_2" State="false" Label="Save slot 2" />
-        <Setting Id="save_slot_3" State="true" Label="Save slot 3" />
-    </Setting>
-
     <Setting Id="any_category" State="true" Label="Any% splits">
         <Setting Id="a1ss_crypt" State="true" Label="Crypt Any% splits">
             <Setting Id="a1s_first_journal" State="true" Label="1st journal entry" ToolTip="Finish the 1st journal entry and exit the room" />

--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -83,7 +83,6 @@ update
         vars.oldPlaceId = old.gameSave1PlaceId;
         vars.currentLevelId = current.gameSave1LevelId;
         vars.currentPlaceId = current.gameSave1PlaceId;
-        vars.currentPortalId = current.gameSave1PortalId;
     }
     else if (vars.SaveSlotNumber == 2)
     {
@@ -91,7 +90,6 @@ update
         vars.oldPlaceId = old.gameSave2PlaceId;
         vars.currentLevelId = current.gameSave2LevelId;
         vars.currentPlaceId = current.gameSave2PlaceId;
-        vars.currentPortalId = current.gameSave2PortalId;
     }
     else if (vars.SaveSlotNumber == 3)
     {
@@ -99,7 +97,6 @@ update
         vars.oldPlaceId = old.gameSave3PlaceId;
         vars.currentLevelId = current.gameSave3LevelId;
         vars.currentPlaceId = current.gameSave3PlaceId;
-        vars.currentPortalId = current.gameSave3PortalId;
     }
 
     /* The next section checks if inventory needs to be forced open, so we can split when the inventory is actually open. */
@@ -140,6 +137,7 @@ onReset
     vars.isInventoryForcedOpenNeeded = false;
     vars.isInventoryForcedOpen = false;
     vars.isCanteenTimerTriggered = false;
+    vars.SaveSlotNumber = 0;
 }
 
 start


### PR DESCRIPTION
I am checking all the save slots until I detect a change from level A01_Crypte to A02_CrypteEscalier
I removed isFreshFirstRoom check from the main menu quitting check - the detection here is quite late
It will (most likely) cause the splitter to start when loading an existing save, but it won't make any splits anyways
There *might* be a better way but I can't think of it right now