### PR TITLE
Add checks to prevent duplicate splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
-# Chants of Sennaar Autosplitter v0.2.0
+# Chants of Sennaar Autosplitter v1.0.0
 
 ## Known bugs
-- Some splits will trigger multiple times during true ending run
+None as of 5th June 2024.
 
 ## How to install
 1. [Download](https://github.com/just-ero/asl-help/raw/main/lib/asl-help) `asl-help` and place it in your LiveSplit installation folder > Components
@@ -15,4 +15,4 @@
 ## Current functionalities
 - Automatic save slot detection
 - Selecting between Any% and True Ending categories
-- Selecting individual splits (reccomended to keep them all on)
+- Selecting individual splits (recommended to keep them all on)

--- a/chantsofsennaar.Settings.xml
+++ b/chantsofsennaar.Settings.xml
@@ -39,7 +39,7 @@
         </Setting>
 
         <Setting Id="a6ss_exile" State="true" Label="Exile (Anchorites) Any% splits">
-            <Setting Id="a6s_exile_npc_room" State="true" Label="Enter the Creator's room" ToolTip="Enter the Creator's room after entering the code in the keypad" />
+            <Setting Id="a6s_creator_room" State="true" Label="Enter the Creator's room" ToolTip="Enter the Creator's room after entering the code in the keypad" />
             <Setting Id="a6s_pick_up_exile_key" State="true" Label="Pick up the Exile key" ToolTip="Pick up the Exile key during the cutscene with the Creator" />
         </Setting>
     </Setting>
@@ -85,7 +85,7 @@
         </Setting>
 
         <Setting Id="t6ss_exile" State="true" Label="Exile (Anchorites) True Ending splits">
-            <Setting Id="t6s_exile_npc_room" State="true" Label="Enter the Creator's room" ToolTip="Enter the Creator's room after entering the code in the keypad" />
+            <Setting Id="t6s_creator_room" State="true" Label="Enter the Creator's room" ToolTip="Enter the Creator's room after entering the code in the keypad" />
             <Setting Id="t6s_pick_up_exile_key" State="true" Label="Pick up the Exile key" ToolTip="Pick up the Exile key during the cutscene with the Creator" />
         </Setting>
 

--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -39,7 +39,7 @@ init
         vars.Helper["inventoryState"] = mono.Make<int>("GameController", "staticInstance", "inventory", "state");
         vars.Helper["isInventoryNeedOpen"] = mono.Make<bool>("GameController", "staticInstance", "inventory", "needOpen");
         // Gets the number of lines solved in the linking terminal.
-        vars.Helper["terminalLinkUIProgress"] = mono.Make<int>("GameController", "staticInstance", "uiController", "terminalUI", "terminalLinkUI", "overed");
+        vars.Helper["terminalProgress"] = mono.Make<int>("GameController", "staticInstance", "uiController", "terminalUI", "terminalLinkUI", "overed");
 
         return true;
     });
@@ -250,7 +250,7 @@ split
         var pickUpLens = vars.isInventoryForcedOpen && vars.CheckSplit(23, 23, "a2s_pick_up_lens", "t2s_pick_up_lens");
 
         // True Ending - Devotee-Alchemist link 
-        var devoteeAlchemistLink = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.CheckSplit(16, 16, "t7s_devo_alch", null);
+        var devoteeAlchemistLink = old.terminalProgress < 5 && current.terminalProgress == 5 && vars.CheckSplit(16, 16, "t7s_devo_alch", null);
 
         return firstJournal || cryptExit || hideAndSeek || pickUpCoin || enterChurch || pickUpLens || devoteeAlchemistLink;
     }
@@ -276,7 +276,7 @@ split
         var armoryExit = vars.CheckSplit(16, 14, "a3s_armory_exit", "t3s_armory_exit");
 
         // True Ending - Warrior-Alchemist link
-        var warriorAlchemistLink = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.CheckSplit(21, 21, "t7s_warr_alch", null);
+        var warriorAlchemistLink = old.terminalProgress < 5 && current.terminalProgress == 5 && vars.CheckSplit(21, 21, "t7s_warr_alch", null);
 
         return spearRoom || stealthStart || stealthCorridor || stealthStorageRoom || armoryExit || warriorAlchemistLink;
     }
@@ -304,7 +304,7 @@ split
         var pickUpTorch = vars.isInventoryForcedOpen && vars.CheckSplit(18, 18, "a4s_pick_up_windmill_torch", "t4s_pick_up_windmill_torch");
 
         // True Ending - Devotee-Bard link
-        var devoteeBardLink = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.CheckSplit(25, 25, "t7s_devo_bard", null);
+        var devoteeBardLink = old.terminalProgress < 5 && current.terminalProgress == 5 && vars.CheckSplit(25, 25, "t7s_devo_bard", null);
 
         return servantDoor || enterSewers || theatreTicket || theatreWatched || exitSewers || pickUpTorch || devoteeBardLink;
     }
@@ -326,7 +326,7 @@ split
         var pickUpSilverBar = vars.isInventoryForcedOpen && vars.CheckSplit(22, 22, "a5s_pick_up_silver_bar", "t5s_pick_up_silver_bar");
 
         // True Ending - Bard-Alchemist split
-        var bardAlchemistSplit = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.CheckSplit(19, 19, "t7s_bard_alch", null);
+        var bardAlchemistSplit = old.terminalProgress < 5 && current.terminalProgress == 5 && vars.CheckSplit(19, 19, "t7s_bard_alch", null);
 
         return mazeExit || escapeMonster || triggerCanteenTimer || pickUpSilverware || pickUpSilverBar || bardAlchemistSplit;
     }

--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -127,7 +127,7 @@ update
     else
     {
         // No save slot has been selected yet.
-        // print("No save slot selected yet, exiting early.");
+        print("No save slot selected yet, exiting early.");
         return false;
     }
 

--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -222,14 +222,6 @@ onStart
 
 split
 {
-    /* ---- Testing logic below ---- 
-    // if (vars.currentPlaceId != vars.oldPlaceId)
-    // {
-    //     print("level + place ids: " + vars.oldLevelId + "," + vars.oldPlaceId + " -> " + vars.currentLevelId + "," + vars.currentPlaceId);
-    //     // return true;
-    // }
-       ---- Testing logic above ---- */
-
     // Crypt + Abbey (Devotees) splits
     if (vars.oldLevelId == 0 && vars.currentLevelId == 0)
     {

--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -168,7 +168,6 @@ onReset
     vars.isTitleScreenToNewSave = false;
     vars.isInventoryForcedOpenNeeded = false;
     vars.isInventoryForcedOpen = false;
-    vars.isCanteenTimerTriggered = false;
 
     vars.splitDict = new Dictionary<string, bool>();
 }
@@ -217,7 +216,6 @@ onStart
     vars.isTitleScreenToNewSave = false;
     vars.isInventoryForcedOpenNeeded = false;
     vars.isInventoryForcedOpen = false;
-    vars.isCanteenTimerTriggered = false;
 
     vars.splitDict = new Dictionary<string, bool>();
 }
@@ -317,30 +315,24 @@ split
     if (vars.oldLevelId == 3 && vars.currentLevelId == 3)
     {
         // Exit the maze.
-        var isMazeExitSplit = vars.oldPlaceId == 7 && vars.currentPlaceId == 8 && (settings["a4s_maze_exit"] || settings["t4s_maze_exit"]);
+        var mazeExit = vars.checkSplit(7, 8, "a4s_maze_exit", "t4s_maze_exit");
         // Escape the monster.
-        var isEscapeMonsterSplit = vars.oldPlaceId == 13 && vars.currentPlaceId == 14 && (settings["a5s_escape_monster"] || settings["t5s_escape_monster"]);
+        var escapeMonster = vars.checkSplit(13, 14, "a5s_escape_monster", "t5s_escape_monster");
         // Trigger the canteen timer (i.e. enter the canteen foyer for the 1st time).
-        var isTriggerCanteenTimerSplit = vars.oldPlaceId == 31 && vars.currentPlaceId == 32 && !vars.isCanteenTimerTriggered && (settings["a5s_trigger_canteen_timer"] || settings["t5s_trigger_canteen_timer"]);
+        var triggerCanteenTimer = vars.checkSplit(31, 32, "a5s_trigger_canteen_timer", "t5s_trigger_canteen_timer");
         // Pick up silverware item at canteen.
-        var isPickUpSilverwareSplit = vars.currentPlaceId == 33 && vars.isInventoryForcedOpen && (settings["a5s_pick_up_silverware"] || settings["t5s_pick_up_silverware"]);
+        var pickUpSilverware = vars.isInventoryForcedOpen && vars.checkSplit(33, 33, "a5s_pick_up_silverware", "t5s_pick_up_silverware");
         // Pick up silver bar item after melting the silverware.
-        var isPickUpSilverBarSplit = vars.currentPlaceId == 22 && vars.isInventoryForcedOpen && (settings["a5s_pick_up_silver_bar"] || settings["t5s_pick_up_silver_bar"]);
+        var pickUpSilverBar = vars.isInventoryForcedOpen && vars.checkSplit(22, 22, "a5s_pick_up_silver_bar", "t5s_pick_up_silver_bar");
 
-        // True Ending - Bards - Alchemists split
-        var isBardAlchSplit = vars.currentPlaceId == 19 && old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && settings["t7s_bard_alch"];
+        // True Ending - Bard-Alchemist split
+        var bardAlchemistSplit = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.checkSplit(19, 19, "t7s_bard_alch", null);
 
-        // Set vars.isCanteenTimerTriggered so split isn't triggered again when entering the canteen.
-        if (isTriggerCanteenTimerSplit)
-        {
-            vars.isCanteenTimerTriggered = true;
-        }
-
-        return isMazeExitSplit || isEscapeMonsterSplit || isTriggerCanteenTimerSplit || isPickUpSilverwareSplit || isPickUpSilverBarSplit || isBardAlchSplit;
+        return mazeExit || escapeMonster || triggerCanteenTimer || pickUpSilverware || pickUpSilverBar || bardAlchemistSplit;
     }
 
     // Factory -> Exile.
-    if (vars.oldLevelId == 3 && vars.currentLevelId == 4 && (settings["a5s_factory_exit"] || settings["t5s_factory_exit"]))
+    if (vars.oldLevelId == 3 && vars.currentLevelId == 4 && vars.checkSplit(null, null, "a5s_factory_exit", "t5s_factory_exit"))
     {
         return true;
     }

--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -69,7 +69,7 @@ init
     // Function checks if we should split, based on desired old and current place ids, and provided setting names.
     // We use vars.splitDict to ensure we don't split again.
     vars.splitDict = new Dictionary<string, bool>();
-    vars.checkSplit = (Func<int?, int?, string, string, bool>)((oldPlaceId, currentPlaceId, settingName1, settingName2) =>
+    vars.CheckSplit = (Func<int?, int?, string, string, bool>)((oldPlaceId, currentPlaceId, settingName1, settingName2) =>
     {
         var key1 = string.IsNullOrEmpty(settingName1) ? string.Empty : settingName1;
         var key2 = string.IsNullOrEmpty(settingName2) ? string.Empty : settingName2;
@@ -235,28 +235,28 @@ split
     {
         /* Crypt splits */
         // Finish the 1st journal entry and exit the room.
-        var firstJournal = vars.checkSplit(3, 4, "a1s_first_journal", "t1s_first_journal");
+        var firstJournal = vars.CheckSplit(3, 4, "a1s_first_journal", "t1s_first_journal");
         // Crypt -> Abbey (finish the water locks puzzle and exit the room)
-        var cryptExit = vars.checkSplit(5, 6, "a1s_crypt_exit", "t1s_crypt_exit");
+        var cryptExit = vars.CheckSplit(5, 6, "a1s_crypt_exit", "t1s_crypt_exit");
 
         /* Abbey splits */
         // Finish hide and seek and enter the stealth room.
-        var hideAndSeek = vars.checkSplit(9, 11, "a2s_hide_and_seek", "t2s_hide_and_seek");
+        var hideAndSeek = vars.CheckSplit(9, 11, "a2s_hide_and_seek", "t2s_hide_and_seek");
         // Pick up the coin item by finishing the bed puzzle.
-        var pickUpCoin = vars.isInventoryForcedOpen && vars.checkSplit(17, 17, "a2s_pick_up_coin", "t2s_pick_up_coin");
+        var pickUpCoin = vars.isInventoryForcedOpen && vars.CheckSplit(17, 17, "a2s_pick_up_coin", "t2s_pick_up_coin");
         // Enter the church.
-        var enterChurch = vars.checkSplit(12, 21, "a2s_enter_church", "t2s_enter_church");
+        var enterChurch = vars.CheckSplit(12, 21, "a2s_enter_church", "t2s_enter_church");
         // Pick up the lens item after getting the key from the jar and opening the door.
-        var pickUpLens = vars.isInventoryForcedOpen && vars.checkSplit(23, 23, "a2s_pick_up_lens", "t2s_pick_up_lens");
+        var pickUpLens = vars.isInventoryForcedOpen && vars.CheckSplit(23, 23, "a2s_pick_up_lens", "t2s_pick_up_lens");
 
         // True Ending - Devotee-Alchemist link 
-        var devoteeAlchemistLink = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.checkSplit(16, 16, "t7s_devo_alch", null);
+        var devoteeAlchemistLink = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.CheckSplit(16, 16, "t7s_devo_alch", null);
 
         return firstJournal || cryptExit || hideAndSeek || pickUpCoin || enterChurch || pickUpLens || devoteeAlchemistLink;
     }
 
     // Abbey -> Fortress
-    if (vars.oldLevelId == 0 && vars.currentLevelId == 1 && vars.checkSplit(null, null, "a2s_abbey_exit", "t2s_abbey_exit"))
+    if (vars.oldLevelId == 0 && vars.currentLevelId == 1 && vars.CheckSplit(null, null, "a2s_abbey_exit", "t2s_abbey_exit"))
     {
         return true;
     }
@@ -265,24 +265,24 @@ split
     if (vars.oldLevelId == 1 && vars.currentLevelId == 1)
     {
         // Exit the room with the spear.
-        var spearRoom = vars.checkSplit(7, 8, "a3s_spear_room", "t3s_spear_room");
+        var spearRoom = vars.CheckSplit(7, 8, "a3s_spear_room", "t3s_spear_room");
         // Enter the first stealth room.
-        var stealthStart = vars.checkSplit(9, 11, "a3s_stealth_start", "t3s_stealth_start");
+        var stealthStart = vars.CheckSplit(9, 11, "a3s_stealth_start", "t3s_stealth_start");
         // Exit the stealth corridor.
-        var stealthCorridor = vars.checkSplit(0, 12, "a3s_stealth_corridor", "t3s_stealth_corridor");
+        var stealthCorridor = vars.CheckSplit(0, 12, "a3s_stealth_corridor", "t3s_stealth_corridor");
         // Exit the stealth storage room (has an elevator wtih 2 boxes).
-        var stealthStorageRoom = vars.checkSplit(13, 14, "a3s_stealth_storage_room", "t3s_stealth_storage_room");
+        var stealthStorageRoom = vars.CheckSplit(13, 14, "a3s_stealth_storage_room", "t3s_stealth_storage_room");
         // Exit the armory room after disguising as a guard.
-        var armoryExit = vars.checkSplit(16, 14, "a3s_armory_exit", "t3s_armory_exit");
+        var armoryExit = vars.CheckSplit(16, 14, "a3s_armory_exit", "t3s_armory_exit");
 
         // True Ending - Warrior-Alchemist link
-        var warriorAlchemistLink = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.checkSplit(21, 21, "t7s_warr_alch", null);
+        var warriorAlchemistLink = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.CheckSplit(21, 21, "t7s_warr_alch", null);
 
         return spearRoom || stealthStart || stealthCorridor || stealthStorageRoom || armoryExit || warriorAlchemistLink;
     }
 
     // Fortress -> Gardens.
-    if (vars.oldLevelId == 1 && vars.currentLevelId == 2 && vars.checkSplit(null, null,"a3s_fortress_exit", "t3s_fortress_exit"))
+    if (vars.oldLevelId == 1 && vars.currentLevelId == 2 && vars.CheckSplit(null, null,"a3s_fortress_exit", "t3s_fortress_exit"))
     {
         return true;
     }
@@ -291,20 +291,20 @@ split
     if (vars.oldLevelId == 2 && vars.currentLevelId == 2)
     {
         // Exit through the servant's door.
-        var servantDoor = vars.checkSplit(2, 5, "a4s_servant_door", "t4s_servant_door");
+        var servantDoor = vars.CheckSplit(2, 5, "a4s_servant_door", "t4s_servant_door");
         // Enter sewers.
-        var enterSewers = vars.checkSplit(15, 11, "a4s_enter_sewers", null);
+        var enterSewers = vars.CheckSplit(15, 11, "a4s_enter_sewers", null);
         // Get theatre ticket.
-        var theatreTicket = vars.isInventoryForcedOpen && vars.checkSplit(17, 17, "t4s_theatre_ticket", null);
+        var theatreTicket = vars.isInventoryForcedOpen && vars.CheckSplit(17, 17, "t4s_theatre_ticket", null);
         // Watch the show.
-        var theatreWatched = vars.checkSplit(23, 24, "t4s_theatre_watched", null);
+        var theatreWatched = vars.CheckSplit(23, 24, "t4s_theatre_watched", null);
         // Exit sewers.
-        var exitSewers = vars.checkSplit(11, 15, "a4s_exit_sewers", "t4s_exit_sewers");
+        var exitSewers = vars.CheckSplit(11, 15, "a4s_exit_sewers", "t4s_exit_sewers");
         // Pick up torch item at windmill.
-        var pickUpTorch = vars.isInventoryForcedOpen && vars.checkSplit(18, 18, "a4s_pick_up_windmill_torch", "t4s_pick_up_windmill_torch");
+        var pickUpTorch = vars.isInventoryForcedOpen && vars.CheckSplit(18, 18, "a4s_pick_up_windmill_torch", "t4s_pick_up_windmill_torch");
 
         // True Ending - Devotee-Bard link
-        var devoteeBardLink = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.checkSplit(25, 25, "t7s_devo_bard", null);
+        var devoteeBardLink = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.CheckSplit(25, 25, "t7s_devo_bard", null);
 
         return servantDoor || enterSewers || theatreTicket || theatreWatched || exitSewers || pickUpTorch || devoteeBardLink;
     }
@@ -315,24 +315,24 @@ split
     if (vars.oldLevelId == 3 && vars.currentLevelId == 3)
     {
         // Exit the maze.
-        var mazeExit = vars.checkSplit(7, 8, "a4s_maze_exit", "t4s_maze_exit");
+        var mazeExit = vars.CheckSplit(7, 8, "a4s_maze_exit", "t4s_maze_exit");
         // Escape the monster.
-        var escapeMonster = vars.checkSplit(13, 14, "a5s_escape_monster", "t5s_escape_monster");
+        var escapeMonster = vars.CheckSplit(13, 14, "a5s_escape_monster", "t5s_escape_monster");
         // Trigger the canteen timer (i.e. enter the canteen foyer for the 1st time).
-        var triggerCanteenTimer = vars.checkSplit(31, 32, "a5s_trigger_canteen_timer", "t5s_trigger_canteen_timer");
+        var triggerCanteenTimer = vars.CheckSplit(31, 32, "a5s_trigger_canteen_timer", "t5s_trigger_canteen_timer");
         // Pick up silverware item at canteen.
-        var pickUpSilverware = vars.isInventoryForcedOpen && vars.checkSplit(33, 33, "a5s_pick_up_silverware", "t5s_pick_up_silverware");
+        var pickUpSilverware = vars.isInventoryForcedOpen && vars.CheckSplit(33, 33, "a5s_pick_up_silverware", "t5s_pick_up_silverware");
         // Pick up silver bar item after melting the silverware.
-        var pickUpSilverBar = vars.isInventoryForcedOpen && vars.checkSplit(22, 22, "a5s_pick_up_silver_bar", "t5s_pick_up_silver_bar");
+        var pickUpSilverBar = vars.isInventoryForcedOpen && vars.CheckSplit(22, 22, "a5s_pick_up_silver_bar", "t5s_pick_up_silver_bar");
 
         // True Ending - Bard-Alchemist split
-        var bardAlchemistSplit = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.checkSplit(19, 19, "t7s_bard_alch", null);
+        var bardAlchemistSplit = old.terminalLinkUIProgress < 5 && current.terminalLinkUIProgress == 5 && vars.CheckSplit(19, 19, "t7s_bard_alch", null);
 
         return mazeExit || escapeMonster || triggerCanteenTimer || pickUpSilverware || pickUpSilverBar || bardAlchemistSplit;
     }
 
     // Factory -> Exile.
-    if (vars.oldLevelId == 3 && vars.currentLevelId == 4 && vars.checkSplit(null, null, "a5s_factory_exit", "t5s_factory_exit"))
+    if (vars.oldLevelId == 3 && vars.currentLevelId == 4 && vars.CheckSplit(null, null, "a5s_factory_exit", "t5s_factory_exit"))
     {
         return true;
     }
@@ -342,35 +342,37 @@ split
     {
         /* Exile splits */
         // Enter the Creator's room after entering the 3-glyph code in the keypad.
-        var isExileNpcRoomSplit = vars.oldPlaceId == 15 && vars.currentPlaceId == 6 && (settings["a6s_exile_npc_room"] || settings["t6s_exile_npc_room"]);
+        var exileCreatorRoom = vars.CheckSplit(15, 6, "a6s_creator_room", "t6s_creator_room");
         // Pick up Exile key.
-        var isPickUpExileKeySplit = vars.currentPlaceId == 24 && vars.isInventoryForcedOpen && (settings["a6s_pick_up_exile_key"] || settings["t6s_pick_up_exile_key"]);
+        var pickUpExileKey = vars.isInventoryForcedOpen && vars.CheckSplit(24, 24, "a6s_pick_up_exile_key", "t6s_pick_up_exile_key");
+        
+        var checkFinalCutscene = !current.canPlayerRun && !old.cursorOff && current.cursorOff;
         // Final split (not optional) for Any% category. Fake tower split for True Ending category
-        var isSadTowerSplit = vars.currentPlaceId == 2 && !current.canPlayerRun && !old.cursorOff && current.cursorOff && (settings["any_category"] || settings["t7s_fake_tower"]);
+        var sadTower = checkFinalCutscene && vars.CheckSplit(2, 2, "any_category", "t7s_fake_tower");
         // Final split (not optional) for True Ending category
-        var isHappyTowerSplit = vars.currentPlaceId == 3 && !current.canPlayerRun && !old.cursorOff && current.cursorOff && settings["true_ending_category"];
+        var happyTower = checkFinalCutscene && vars.CheckSplit(3, 3, "true_ending_category", null);
 
         /* Laboratories True Ending splits */
-        var isAbbeyLabSplit = vars.oldPlaceId == 9 && vars.currentPlaceId == 16 && settings["t7s_abbey_lab"];
-        var isFortressLabSplit = vars.oldPlaceId == 9 && vars.currentPlaceId == 17 && settings["t7s_fortress_lab"];
-        var isGardensLabSplit = vars.oldPlaceId == 9 && vars.currentPlaceId == 18 && settings["t7s_gardens_lab"];
-        var isFactoryLabSplit = vars.oldPlaceId == 9 && vars.currentPlaceId == 19 && settings["t7s_factory_lab"];
+        var abbeyLab = vars.CheckSplit(9, 16, "t7s_abbey_lab", null);
+        var fortressLab = vars.CheckSplit(9, 17, "t7s_fortress_lab", null);
+        var gardensLab = vars.CheckSplit(9, 18, "t7s_gardens_lab", null);
+        var factoryLab = vars.CheckSplit(9, 19, "t7s_factory_lab", null);
 
-        return isExileNpcRoomSplit || isPickUpExileKeySplit || isSadTowerSplit || isHappyTowerSplit || isAbbeyLabSplit || isFortressLabSplit || isGardensLabSplit || isFactoryLabSplit;
+        return exileCreatorRoom || pickUpExileKey || sadTower || happyTower || abbeyLab || fortressLab || gardensLab || factoryLab;
     }
 
     // Simulation splits
     if (vars.oldLevelId == 5 && vars.currentLevelId == 5)
     {
-        var isTerminal1Split = vars.oldPlaceId == 4 && vars.currentPlaceId == 7 && settings["t8s_terminal_1"];
-        var isTerminal2Split = vars.oldPlaceId == 11 && vars.currentPlaceId == 12 && settings["t8s_terminal_2"];
-        var isTerminal3Split = vars.oldPlaceId == 13 && vars.currentPlaceId == 16 && settings["t8s_terminal_3"];
+        var terminal1 = vars.CheckSplit(4, 7, "t8s_terminal_1", null);
+        var terminal2 = vars.CheckSplit(11, 12, "t8s_terminal_2", null);
+        var terminal3 = vars.CheckSplit(13, 16, "t8s_terminal_3", null);
 
-        return isTerminal1Split || isTerminal2Split || isTerminal3Split;
+        return terminal1 || terminal2 || terminal3;
     }
 
     // Simuation end
-    if (vars.oldLevelId == 5 && vars.currentLevelId == 4 && settings["t8s_exile_shutdown"])
+    if (vars.oldLevelId == 5 && vars.currentLevelId == 4 && vars.CheckSplit(null, null, "t8s_exile_shutdown", null))
     {
         return true;
     }


### PR DESCRIPTION
I have not tested this PR in a full run yet.

Changes:
* Add `vars.CheckSplit` function to check for 1) matching old and current place ids, 2) settings, and 3) split is not a duplicate
  * All checks have been simplified using this new function
  * `vars.isCanteenTimerTriggered` is removed, since `vars.CheckSplit` should prevent the duplicate split now
* Rename most check variables to be shorter
* Rename `terminalLinkUIProgress` to `terminalProgress`
* Fix "True Ending - Devotees-Bards link" to read `settings["t7s_devo_bard"]` instead of `settings["t7s_warr_alch"]`
* Rename `X6s_exile_npc_room` setting to `X6s_creator_room`